### PR TITLE
fix: load the preferred language instead of the least preferred one

### DIFF
--- a/src/render.tsx
+++ b/src/render.tsx
@@ -28,13 +28,11 @@ export function render(jsonText: string) {
   })
 
   let localeJson: any
-  navigator.languages.forEach((lang) => {
-    try {
-      if (!localeJson) localeJson = require(`l10n/${lang}.properties`)
-    } catch (err) {
-      logDebug('locale not found', lang)
-    }
-  })
+  try {
+    if (!localeJson) localeJson = require(`l10n/${navigator.languages[0]}.properties`)
+  } catch (err) {
+    logDebug('locale not found', navigator.languages[0])
+  }
 
   const JSONView = {
     json: new Text(jsonText),

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -29,7 +29,7 @@ export function render(jsonText: string) {
 
   let localeJson: any
   try {
-    if (!localeJson) localeJson = require(`l10n/${navigator.languages[0]}.properties`)
+    localeJson = require(`l10n/${navigator.languages[0]}.properties`)
   } catch (err) {
     logDebug('locale not found', navigator.languages[0])
   }

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -27,18 +27,24 @@ export function render(jsonText: string) {
     }
   })
 
-  let localeJson: any
-  try {
-    localeJson = require(`l10n/${navigator.languages[0]}.properties`)
-  } catch (err) {
-    logDebug('locale not found', navigator.languages[0])
+  const defaultLocale = require('devtools/client/locales/en-US/jsonview.properties')
+
+  let locale: any
+  for (const lang of navigator.languages) {
+    try {
+      if (!locale) {
+        locale =
+          lang === 'en-US' ? defaultLocale : require(`l10n/${lang}.properties`)
+        break
+      }
+    } catch (err) {
+      logDebug('locale not found', lang)
+    }
   }
 
   const JSONView = {
     json: new Text(jsonText),
-    Locale:
-      localeJson ??
-      require('devtools/client/locales/en-US/jsonview.properties'),
+    Locale: locale ?? defaultLocale,
     headers: {
       request: [],
       response: [],


### PR DESCRIPTION
Fixes #16, by loading [0] of `navigator.languages`. Also, `navigator.languages[0]` is always defined as you need to have at least one language pack installed.
![image](https://user-images.githubusercontent.com/84628826/161278261-2ff63207-dd0f-4f17-8d84-a6208b2fa4e2.png)
